### PR TITLE
[TECHNICAL SUPPORT] LPS-76531 The 'ddm-link-to-page' field shows only the first 10 parent/child pages in the radio selector.

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1887,7 +1887,7 @@ AUI.add(
 									instance._requestLayouts(parentLayoutId, groupId, privateLayout, start, end, A.rbind('_renderLayoutsFragment', instance, key, 'up'));
 								}
 							}
-							else if (scrollTop + innerHeight === scrollHeight) {
+							else if (Math.trunc(scrollTop) + innerHeight === scrollHeight) {
 								start = end;
 								end = start + delta;
 


### PR DESCRIPTION
Hello @antonio-ortega ,

The problem comes when you zoom out (with ctrl+mouse wheel) to 67%-80% in the browser. This can result in a decimal "scrollTop" value. In that case the addition of "scrollTop" and "innerHeight" is higher then "scrollHeight" by that decimal amount. Math.trunc() takes care of that problem.
Thank you!