### PR TITLE
[TECHNICAL SUPPORT] LPS-77158 Quickly switching language in web content breaks the content of editor

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -2749,11 +2749,22 @@ AUI.add(
 
 						var editor = instance.getEditor();
 
+						var editorComponentName = instance.getInputName() + 'Editor';
+
+						var localizationMap = instance.get('localizationMap');
+
 						if (isNode(editor)) {
 							TextHTMLField.superclass.setValue.apply(instance, arguments);
 						}
-						else {
+						else if(editor.instanceReady) {
 							editor.setHTML(value);
+						}
+						else {
+							Liferay.after(editorComponentName + ':registered', function() {
+								if(value === localizationMap[instance.get('displayLocale')]) {
+									editor.setHTML(value);
+								}
+							});
 						}
 					},
 

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -2756,12 +2756,12 @@ AUI.add(
 						if (isNode(editor)) {
 							TextHTMLField.superclass.setValue.apply(instance, arguments);
 						}
-						else if(editor.instanceReady) {
+						else if (editor.instanceReady) {
 							editor.setHTML(value);
 						}
 						else {
 							Liferay.after(editorComponentName + ':registered', function() {
-								if(value === localizationMap[instance.get('displayLocale')]) {
+								if (value === localizationMap[instance.get('displayLocale')]) {
 									editor.setHTML(value);
 								}
 							});

--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
@@ -356,17 +356,17 @@ AUI.add(
 					_onInstanceReady: function() {
 						var instance = this;
 
-						instance.instanceReady = true;
-
 						var editorNamespace = instance.get('namespace');
 
-						window[editorNamespace].instanceReady = true;
+						instance.instanceReady = true;
 
-						Liferay.component(editorNamespace, window[editorNamespace]);
+						window[editorNamespace].instanceReady = true;
 
 						if (instance.customDataProcessorLoaded || !instance.get('useCustomDataProcessor')) {
 							instance._initializeData();
 						}
+
+						Liferay.component(editorNamespace, window[editorNamespace]);
 
 						// LPS-73775
 


### PR DESCRIPTION
-Listening to Liferay.component's :registered event in ddm_form.js to wait for initial Render with setHTML
-Calling Liferay.component in alloyeditor.js  after _initializeData()

[LPS-77158](https://issues.liferay.com/browse/LPS-77158)
[Already merged commits regarding this issue](https://github.com/brianchandotcom/liferay-portal/compare/234e0c3298...58f32250fc)

Please review it, Thank you