### PR TITLE
[TECHNICAL SUPPORT] LPS-83318 Sign in Portlet is maximized upon failed login, even when a full sized sign in portlet is on the page

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -297,7 +297,8 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			SessionErrors.add(actionRequest, "login", login);
 		}
 
-		if (portletName.equals(LoginPortletKeys.LOGIN)) {
+		if (portletName.equals(LoginPortletKeys.LOGIN) &&
+				(actionRequest.getWindowState() != WindowState.NORMAL)) {
 			portletURL.setWindowState(WindowState.MAXIMIZED);
 		}
 		else {


### PR DESCRIPTION
Hey @antonio-ortega ,
LPS:
[LPS-83318](https://issues.liferay.com/browse/LPS-83318)
SME request:
[LPP-30768](https://issues.liferay.com/browse/LPP-30768)

The issue is we maximize the login portlet upon failed login attempt, when there is a full sized log in portlet on the page.In that scenario, the failed login attempt should be displayed in the full sized login portlet without maximizing it to full screen.
See the SME request for further details regarding the expected and current behavior.
Please review the PR.

Thanks,