### PR TITLE
[TECHNICAL SUPPORT] LPS-83595 Anchor references are lost using CKEditor in HTML format when using whitespace that is not allowed in ID

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/link/dialogs/anchor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/link/dialogs/anchor.js
@@ -1,0 +1,120 @@
+/**
+ * @license Copyright (c) 2003-2013, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.html or http://ckeditor.com/license
+ */
+
+CKEDITOR.dialog.add( 'anchor', function( editor ) {
+	// Function called in onShow to load selected element.
+	var loadElements = function( element ) {
+			this._.selectedElement = element;
+
+			var attributeValue = element.data( 'cke-saved-name' );
+			this.setValueOf( 'info', 'txtName', attributeValue || '' );
+		};
+
+	function createFakeAnchor( editor, anchor ) {
+		return editor.createFakeElement( anchor, 'cke_anchor', 'anchor' );
+	}
+
+	return {
+		title: editor.lang.link.anchor.title,
+		minWidth: 300,
+		minHeight: 60,
+		onOk: function() {
+			var name = CKEDITOR.tools.trim( this.getValueOf( 'info', 'txtName' ) ).split(" ").join("_");
+			var attributes = {
+				id: name,
+				name: name,
+				'data-cke-saved-name': name
+			};
+
+			if ( this._.selectedElement ) {
+				if ( this._.selectedElement.data( 'cke-realelement' ) ) {
+					var newFake = createFakeAnchor( editor, editor.document.createElement( 'a', { attributes: attributes } ) );
+					newFake.replace( this._.selectedElement );
+				} else
+					this._.selectedElement.setAttributes( attributes );
+			} else {
+				var sel = editor.getSelection(),
+					range = sel && sel.getRanges()[ 0 ];
+
+				// Empty anchor
+				if ( range.collapsed ) {
+					if ( CKEDITOR.plugins.link.synAnchorSelector )
+						attributes[ 'class' ] = 'cke_anchor_empty';
+
+					if ( CKEDITOR.plugins.link.emptyAnchorFix ) {
+						attributes[ 'contenteditable' ] = 'false';
+						attributes[ 'data-cke-editable' ] = 1;
+					}
+
+					var anchor = editor.document.createElement( 'a', { attributes: attributes } );
+
+					// Transform the anchor into a fake element for browsers that need it.
+					if ( CKEDITOR.plugins.link.fakeAnchor )
+						anchor = createFakeAnchor( editor, anchor );
+
+					range.insertNode( anchor );
+				} else {
+					if ( CKEDITOR.env.ie && CKEDITOR.env.version < 9 )
+						attributes[ 'class' ] = 'cke_anchor';
+
+					// Apply style.
+					var style = new CKEDITOR.style({ element: 'a', attributes: attributes } );
+					style.type = CKEDITOR.STYLE_INLINE;
+					editor.applyStyle( style );
+				}
+			}
+		},
+
+		onHide: function() {
+			delete this._.selectedElement;
+		},
+
+		onShow: function() {
+			var selection = editor.getSelection(),
+				fullySelected = selection.getSelectedElement(),
+				partialSelected;
+
+			// Detect the anchor under selection.
+			if ( fullySelected ) {
+				if ( CKEDITOR.plugins.link.fakeAnchor ) {
+					var realElement = CKEDITOR.plugins.link.tryRestoreFakeAnchor( editor, fullySelected );
+					realElement && loadElements.call( this, realElement );
+					this._.selectedElement = fullySelected;
+				} else if ( fullySelected.is( 'a' ) && fullySelected.hasAttribute( 'name' ) )
+					loadElements.call( this, fullySelected );
+			} else {
+				partialSelected = CKEDITOR.plugins.link.getSelectedLink( editor );
+				if ( partialSelected ) {
+					loadElements.call( this, partialSelected );
+					selection.selectElement( partialSelected );
+				}
+			}
+
+			this.getContentElement( 'info', 'txtName' ).focus();
+		},
+		contents: [
+			{
+			id: 'info',
+			label: editor.lang.link.anchor.title,
+			accessKey: 'I',
+			elements: [
+				{
+				type: 'text',
+				id: 'txtName',
+				label: editor.lang.link.anchor.name,
+				required: true,
+				validate: function() {
+					if ( !this.getValue() ) {
+						alert( editor.lang.link.anchor.errorName );
+						return false;
+					}
+					return true;
+				}
+			}
+			]
+		}
+		]
+	};
+});


### PR DESCRIPTION
Hey @antonio-ortega ,

Please review this PR.
[LPS-83595](https://issues.liferay.com/browse/LPS-83595)
In ckeditor's link plugin, when the user wants to create an anchor link, we allow spaces. However according to the HTML5 ID specifications, spaces are not allowed in ID, and the POST does not send the id attribute including spaces, just the <a> tag without the 'href'.

I fixed this issue by replacing spaces to "_" character, when the user saves the name of the anchor.
at line 24: 
from `var name = CKEDITOR.tools.trim( this.getValueOf( 'info', 'txtName' ) );`
to `var name = CKEDITOR.tools.trim( this.getValueOf( 'info', 'txtName' ) ).split(" ").join("_");`

Ckeditor trims the name of the anchor from spaces, but just from the beginning and the end of the string. With the changes I made, the spaces will be replaced inside the string. 
The user will see the replaced characters when he/she tries to use the anchor for a link. That`s why I thought I can handle this replace silently.

Unfortunately I could not find any resource about the workflow to fix 3th party plugins for ckeditor.
I applied my changes in the _diffs folder. Please let me know if I should send a PR for liferay/liferay-ckeditor repo as well, or If I missed a step.

Thanks,