### PR TITLE
[TS] LPS-86376 Get zIndex from Liferay.zIndex.TOOLTIP instead of Liferay.zIndex.WINDOW

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_viewer.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_viewer.js
@@ -387,13 +387,11 @@ AUI.add(
 							}
 						);
 
-						var editEntityBaseZIndex = parent.CKEDITOR ? parent.CKEDITOR.getNextZIndex() : Liferay.zIndex.WINDOW;
-
 						Liferay.Util.editEntity(
 							{
 								dialog: {
 									destroyOnHide: true,
-									zIndex: editEntityBaseZIndex + 100
+									zIndex: Liferay.zIndex.WINDOW + 100
 								},
 								id: instance.get('id'),
 								stack: false,

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_viewer.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_viewer.js
@@ -391,7 +391,7 @@ AUI.add(
 							{
 								dialog: {
 									destroyOnHide: true,
-									zIndex: Liferay.zIndex.WINDOW + 100
+									zIndex: Liferay.zIndex.TOOLTIP + 100
 								},
 								id: instance.get('id'),
 								stack: false,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86376

Hi @antonio-ortega 

I am sending you the pr with zIndex problem. 
After LPS-86068 it is working in webcontent admin but it is not working in webcontent display portlet edition.

In webcontent display portlet, `parent.CKEditor` returns undefined. I have verified that CKEditor object is in `parent.frames[0].CKEditor`

From my point of view, we have three options:
   1) Modify code and look for CKEditor object in all frames
   2) Get zIndex from caller
   3) Set zIndex with a big number (for example TOOLTIP)

Today I will be available since 15.00

Thank you!