### PR TITLE
[TECHNICAL SUPPORT] LPS-86490 Empty notification container of session time-out remains in the dom with 2px padding that makes UI elements nonclickable

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_notification.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_notification.scss
@@ -16,13 +16,11 @@
 	overflow: auto;
 	padding-left: 15px;
 	padding-right: 15px;
-	padding-top: 15px;
 	position: fixed;
 	width: 100%;
 	z-index: 5000;
 
 	.lfr-notification-wrapper {
-		margin-bottom: 5px;
 		overflow: hidden;
 		overflow-wrap: break-word;
 		word-wrap: break-word;


### PR DESCRIPTION
Hey @antonio-ortega,

[LPS-86490](https://issues.liferay.com/browse/LPS-86490) 

Please see [my comment on LPS-84988](https://issues.liferay.com/browse/LPS-84988?focusedCommentId=1604312&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1604312)
My original fix caused a regression that led to the discovery that the remaining notification container is an intended design decision.

However the remaining container still has a calculated height that could lead to blocked UI elements. This behavior is the same in master as well, that`s why I chose to make the PR to master first.

I`m planning to revert LPS-84988 on 7.0.x under LPS-86490, when I backport this solution.
Solving the regression and the original problem.

Please review my fix.

Thanks,