### PR TITLE
[TECHNICAL SUPPORT] LPS-85074 Child pages may disappear if the mouse is not moved quickly enough

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/navigation_interaction.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/navigation_interaction.js
@@ -7,6 +7,8 @@ AUI.add(
 
 		var DIRECTION_RIGHT = 'right';
 
+		var DEBOUNCED;
+
 		var NAME = 'liferaynavigationinteraction';
 
 		var NavigationInteraction = A.Component.create(
@@ -44,6 +46,8 @@ AUI.add(
 
 								var menu = event.menu;
 
+								clearTimeout(instance.DEBOUNCED);
+
 								if (menu) {
 									instance._lastShownMenu = null;
 
@@ -51,8 +55,10 @@ AUI.add(
 										instance._lastShownMenu = menu;
 									}
 
-									menu.toggleClass('hover', showMenu);
-									menu.toggleClass('open', showMenu);
+									instance.DEBOUNCED = setTimeout(function () {
+										menu.toggleClass('hover', showMenu);
+										menu.toggleClass('open', showMenu);
+									}, 200);
 								}
 							}
 						);


### PR DESCRIPTION
Hey @antonio-ortega ,

[LPS-85974](https://issues.liferay.com/browse/LPS-85974) 
I created a solution by debouncing the css toggle on the hover event.

Please review it.

Thanks,