### PR TITLE
[TECHNICAL SUPPORT] LPS-86044 Two error messages are shown in Sign In Portlet

### DIFF
--- a/portal-web/docroot/html/taglib/ui/error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/error/page.jsp
@@ -43,6 +43,10 @@ String rowBreak = (String)request.getAttribute("liferay-ui:error:rowBreak");
 		<aui:script require="metal-dom/src/all/dom as dom,clay-alert/src/ClayToast as ClayToast">
 			let alertContainer = document.getElementById('alertContainer');
 
+			if (AUI().one('.inline-alert-container.lfr-alert-container')) {
+				return;
+			}
+			
 			if (!alertContainer) {
 				alertContainer = document.createElement('div');
 				alertContainer.id = 'alertContainer';


### PR DESCRIPTION
Hey @antonio-ortega ,

[LPS-86044](https://issues.liferay.com/browse/LPS-86044) 
I solved the issue by checking if there is already a displayed App error before rendering the error from the server.
I based my solution on [PTR-438](https://issues.liferay.com/browse/PTR-438) 

> General error message: display it only if there is no detail message(s).

I send the PR to you as my changes are made in the frontend infrastructure.
Please review it,
