### PR TITLE
[TECHNICAL SUPPORT] LPS-85974 Child pages may disappear if the mouse is not moved quickly enough

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/navigation_interaction.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/navigation_interaction.js
@@ -31,6 +31,8 @@ AUI.add(
 
 						var hostULId = '#' + navigation.guid();
 
+						instance._toggleMenuTask = A.debounce(instance._toggleMenu, 200);
+
 						instance._directChildLi = Liferay.Data.NAV_INTERACTION_ITEM_SELECTOR || hostULId + '> li';
 
 						instance._hostULId = hostULId;
@@ -51,8 +53,7 @@ AUI.add(
 										instance._lastShownMenu = menu;
 									}
 
-									menu.toggleClass('hover', showMenu);
-									menu.toggleClass('open', showMenu);
+									instance._toggleMenuTask(menu, showMenu);
 								}
 							}
 						);
@@ -317,7 +318,13 @@ AUI.add(
 
 							instance.MAP_HOVER = {};
 						}
-					}
+					},
+
+ 					_toggleMenu: function(menu, showMenu) {
+						menu.toggleClass('hover', showMenu);
+
+ 						menu.toggleClass('open', showMenu);
+ 					}
 				}
 			}
 		);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/navigation_interaction.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/navigation_interaction.js
@@ -51,6 +51,8 @@ AUI.add(
 
 									if (showMenu) {
 										instance._lastShownMenu = menu;
+
+										instance._toggleMenu(menu, showMenu);
 									}
 
 									instance._toggleMenuTask(menu, showMenu);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/navigation_interaction.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/navigation_interaction.js
@@ -279,11 +279,17 @@ AUI.add(
 
 						var eventType = 'hideNavigationMenu';
 
+						mapHover.menu = event.currentTarget;
+
 						if (event.type == 'mouseenter') {
 							eventType = 'showNavigationMenu';
-						}
 
-						mapHover.menu = event.currentTarget;
+							var dropdown = A.one('.hover.open');
+	
+							if (dropdown && mapHover.menu != dropdown) {
+								instance._toggleMenu(dropdown, false);
+							}
+						}
 
 						Liferay.fire(eventType, mapHover);
 					},


### PR DESCRIPTION
Hey @antonio-ortega , @jbalsas,

[LPS-85974](https://issues.liferay.com/browse/LPS-85974)
I improved on the solution and now the 'showNavigationMenu' event is without delay while still clearing the setTimeOut to avoid closing the dropdown from a delayed 'hideNavigationMenu' event.

Please review it.
Thanks,