### PR TITLE
[TECHNICAL SUPPORT] LPS-8711 Site roles are incorrectly assigned when they are selected from different pages

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -194,7 +194,11 @@ AUI.add(
 							}
 						).filter(
 							function(item) {
-								const itemActions = item.getData('actions');
+								var itemActions;
+
+								if (item) {
+									itemActions = item.getData('actions');
+								}
 
 								return itemActions !== undefined && itemActions !== STR_ACTIONS_WILDCARD;
 


### PR DESCRIPTION
Hello @antonio-ortega ,

[LPS-87117](https://issues.liferay.com/browse/LPS-87117)
I introduced a null check on 'item', as it will be null if it`s hidden / it`s on another page. 
Because of the null check I had to change the const to var.

Please review it,
Thanks