### PR TITLE
[TECHNICAL SUPPORT] LPS-109177 There is no tooltip for truncated page names in the miller columns

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -708,6 +708,8 @@ public class LayoutsAdminDisplayContext {
 			layoutJSONObject.put(
 				"title", layout.getName(themeDisplay.getLocale())
 			).put(
+				"tooltip", isTooltip(layout.getName(themeDisplay.getLocale()))
+			).put(
 				"url", portletURL.toString()
 			);
 
@@ -1535,6 +1537,14 @@ public class LayoutsAdminDisplayContext {
 		}
 
 		return true;
+	}
+
+	public Boolean isTooltip(String string) {
+		if (string.length() >= 28) {
+			return true;
+		}
+
+		return false;
 	}
 
 	protected long getActiveLayoutSetBranchId() throws PortalException {

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/soy/LayoutColumn.es.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/soy/LayoutColumn.es.js
@@ -112,6 +112,7 @@ LayoutColumn.STATE = {
 			pending: Config.bool().value(false),
 			plid: Config.string().required(),
 			title: Config.string().required(),
+			titleLength: Config.bool(),
 			url: Config.string().required()
 		})
 	).required(),

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/soy/LayoutColumn.soy
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/soy/LayoutColumn.soy
@@ -18,6 +18,7 @@
 		pending: bool,
 		plid: string,
 		title: string,
+		tooltip: bool,
 		url: string
 	]>}
 	{@param layoutColumnIndex: number}
@@ -97,6 +98,7 @@
 		plid: string,
 		pending: bool,
 		title: string,
+		tooltip: bool,
 		url: string
 	]}
 	{@param handleLayoutColumnItemCheck: any}
@@ -137,7 +139,12 @@
 
 	<li {$listGroupItemAttributes}>
 		{let $listGroupItemMaskAttributes kind="attributes"}
-			class="layout-column-item-click-mask"
+			{if $layoutColumnItem.tooltip}
+				class="layout-column-item-click-mask lfr-portal-tooltip"
+				title="{$layoutColumnItem.title}"
+			{else}
+				class="layout-column-item-click-mask"
+			{/if}
 			data-layout-column-item-plid="{$layoutColumnItem.plid}"
 			data-onclick="{$handleLayoutColumnItemClick}"
 			tabindex="0"


### PR DESCRIPTION
Hey,
[LPS-109177](https://issues.liferay.com/browse/LPS-109177)

This is my solution for displaying tooltip in the miller columns. Currently any string that is longer than 28 character will be truncated and we will show a tooltip. I understand this is not an ideal solution, but it's back portable and did not require UX design change.

Please review it
Thanks,