### PR TITLE
LPS-109291 Empty value attribute prevents being WCAG 2.1 compliant for accessibility

### DIFF
--- a/util-taglib/src/com/liferay/taglib/ui/LayoutCommonTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/LayoutCommonTag.java
@@ -106,8 +106,8 @@ public class LayoutCommonTag extends IncludeTag {
 
 		jspWriter.write(
 			"<form action=\"#\" class=\"hide\" id=\"hrefFm\" method=\"post\" " +
-				"name=\"hrefFm\"><span></span><input hidden type=\"submit\"/>" +
-					"</form>");
+				"name=\"hrefFm\" aria-hidden=\"true\"><span></span><input " +
+					"hidden type=\"submit\"/></form>");
 
 		return EVAL_PAGE;
 	}


### PR DESCRIPTION
Hey,

Based on [PTR-1510](https://issues.liferay.com/browse/PTR-1510), I sent the solution for review.
[LPS-109291](https://issues.liferay.com/browse/LPS-109291)
Thanks,