### PR TITLE
[TECHNICAL SUPPORT] LPS-109177 There is no tooltip for truncated page names in the miller columns

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/soy/Layout.es.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/soy/Layout.es.js
@@ -98,6 +98,34 @@ class Layout extends Component {
 				this.searchContainer_ = searchContainer;
 			}
 		);
+
+		document
+			.querySelectorAll('.layout-column-item-click-mask')
+			.forEach(element => {
+				element.addEventListener(
+					'mouseover',
+					function isEllipsisActive(e) {
+						var LayoutColumnTitle = document.querySelector(
+							'span[title="' +
+								e.srcElement.getAttribute('data-tooltip') +
+								'"]'
+						);
+
+						if (
+							LayoutColumnTitle &&
+							LayoutColumnTitle.offsetWidth <
+								LayoutColumnTitle.scrollWidth
+						) {
+							e.srcElement.setAttribute(
+								'title',
+								e.srcElement.getAttribute('data-tooltip')
+							);
+							e.srcElement.classList.add('lfr-portal-tooltip');
+						}
+					},
+					{once: true}
+				);
+			});
 	}
 
 	/**

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/soy/LayoutColumn.soy
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/soy/LayoutColumn.soy
@@ -139,6 +139,7 @@
 		{let $listGroupItemMaskAttributes kind="attributes"}
 			class="layout-column-item-click-mask"
 			data-layout-column-item-plid="{$layoutColumnItem.plid}"
+			data-tooltip="{$layoutColumnItem.title}"
 			data-onclick="{$handleLayoutColumnItemClick}"
 			tabindex="0"
 			type="button"
@@ -187,7 +188,7 @@
 
 			<div class="autofit-col autofit-col-expand layout-column-item-title">
 				<h4 class="list-group-title">
-					<span class="text-truncate">
+					<span class="text-truncate" title="{$layoutColumnItem.title}">
 						{$layoutColumnItem.title}
 					</span>
 				</h4>


### PR DESCRIPTION
Hey,

[LPS-109177](https://issues.liferay.com/browse/LPS-109177),

I created a solution based on your suggestion on how to check if the ellipsis is active on an element. Because there is an overlaying button on every truncated page title, I had to activate the tooltip on the button. Please review it.

Thanks,