### PR TITLE
LPS-109009 When portlet.url.anchor.enabled=true, the anchor is added to p_auth parameter in URL

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
@@ -143,6 +143,13 @@
 
 				var authToken = searchParams.get('p_auth') || '';
 
+				var authTokenIndex = authToken.indexOf('#');
+
+				authToken = authToken.substring(
+					0,
+					authTokenIndex != -1 ? authTokenIndex : authToken.length
+				);
+
 				form.append(
 					'<input name="p_auth" type="hidden" value="' +
 						authToken +


### PR DESCRIPTION
Hi @antonio-ortega,

Sending this PR in regards of LPS-109009 (PTR-1521 -- pr-97).
I've found that the issue is reproducible on master as well in case Message Board is added to a page. You can find the reproduction steps on the LPS.

I think the best way to solve it is to remove the anchor from the p_auth parameter as you highlighted, so please check and let me know.

Thank you in advance!
Robert