### PR TITLE
[TECHNICAL SUPPORT] LPS-111558 Liferay pop-ups are not visible when CKEditor is in full-screen mode

### DIFF
--- a/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanFilterMethod.java
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanFilterMethod.java
@@ -22,6 +22,7 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface BeanFilterMethod {
 
-	public Object invoke(Object... arguments) throws ReflectiveOperationException;
+	public Object invoke(Object... arguments)
+		throws ReflectiveOperationException;
 
 }

--- a/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanPortletMethod.java
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanPortletMethod.java
@@ -42,7 +42,8 @@ public interface BeanPortletMethod extends Comparable<BeanPortletMethod> {
 
 	public String getResourceID();
 
-	public Object invoke(Object... arguments) throws ReflectiveOperationException;
+	public Object invoke(Object... arguments)
+		throws ReflectiveOperationException;
 
 	public boolean isEventProcessor(QName qName);
 

--- a/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanPortletMethodWrapper.java
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanPortletMethodWrapper.java
@@ -77,7 +77,9 @@ public abstract class BeanPortletMethodWrapper implements BeanPortletMethod {
 	}
 
 	@Override
-	public Object invoke(Object... arguments) throws ReflectiveOperationException {
+	public Object invoke(Object... arguments)
+		throws ReflectiveOperationException {
+
 		return _beanPortletMethod.invoke(arguments);
 	}
 

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_notification.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_notification.scss
@@ -19,7 +19,7 @@
 	padding-top: 15px;
 	position: fixed;
 	width: 100%;
-	z-index: 5000;
+	z-index: 999999;
 
 	.lfr-notification-wrapper {
 		margin-bottom: 5px;

--- a/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
@@ -142,8 +142,8 @@ public class FileInstallDeployTest {
 			_updateConfiguration(
 				() -> {
 					String content = StringBundler.concat(
-						_TEST_KEY, StringPool.EQUAL, "${", systemTestPropertyKey,
-						"}");
+						_TEST_KEY, StringPool.EQUAL, "${",
+						systemTestPropertyKey, "}");
 
 					Files.write(path, content.getBytes());
 				});


### PR DESCRIPTION
Hey,

[LPS-111558](https://issues.liferay.com/browse/LPS-111558),

We are setting the z-index of our notification container to 5000. This value is fairly low for system warnings and many 3rd party library could interfere with it, like ckeditor in full window mode. As the z-index is stored as a 32-bit signed integer, we can have a maximum value of 2,147,483,467
Meaning we have quite a bit of breathing room to assign a value that makes sense in our environment. I went with '999999'. In liferay we handle the z-index around 10.000 with editor pop-ups, so I felt it's a safe number to use. I also think those notifications are always want to appear with the highest z-index value on our page and shooting higher seems fine in this case.

Please review it