### PR TITLE
LPS-112180 Refactor focus/blur handling

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -574,7 +574,23 @@ AUI.add(
 							duration: 500,
 							message: instance._warningText,
 							on: {
-								blur(event) {
+								click(event) {
+									if (
+										event.domEvent.target.test(
+											'.alert-link'
+										)
+									) {
+										event.domEvent.preventDefault();
+										instance._host.extend();
+									}
+									else if (
+										event.domEvent.target.test('.close')
+									) {
+										instance._destroyBanner();
+										instance._alertClosed = true;
+									}
+								},
+								focus(event) {
 									if (instance._alert) {
 										var notificationContainer = A.one(
 											'.lfr-notification-container'
@@ -590,22 +606,6 @@ AUI.add(
 												'alert'
 											);
 										}
-									}
-								},
-								click(event) {
-									if (
-										event.domEvent.target.test(
-											'.alert-link'
-										)
-									) {
-										event.domEvent.preventDefault();
-										instance._host.extend();
-									}
-									else if (
-										event.domEvent.target.test('.close')
-									) {
-										instance._destroyBanner();
-										instance._alertClosed = true;
 									}
 								},
 							},

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -465,7 +465,9 @@ AUI.add(
 
 					var banner = instance._getBanner();
 
-					var counterTextNode = banner.one('.countdown-timer');
+					var counterTextNode = banner
+						.one('.countdown-timer')
+						.getDOMNode();
 
 					instance._uiSetRemainingTime(
 						remainingTime,
@@ -572,11 +574,23 @@ AUI.add(
 							duration: 500,
 							message: instance._warningText,
 							on: {
-								blur() {
-									A.one('div[role="alert"').setAttribute(
-										'role',
-										'alert'
-									);
+								blur(event) {
+									if (instance._alert) {
+										var notificationContainer = A.one(
+											'.lfr-notification-container'
+										);
+
+										if (
+											!notificationContainer.contains(
+												event.domEvent.relatedTarget
+											)
+										) {
+											instance._alert.setAttribute(
+												'role',
+												'alert'
+											);
+										}
+									}
 								},
 								click(event) {
 									if (
@@ -593,11 +607,6 @@ AUI.add(
 										instance._destroyBanner();
 										instance._alertClosed = true;
 									}
-								},
-								focus() {
-									A.one('div[role="alert"').removeAttribute(
-										'role'
-									);
 								},
 							},
 							title: Liferay.Language.get('warning'),
@@ -646,15 +655,23 @@ AUI.add(
 					DOC.title = instance.get('pageTitle');
 				},
 
-				_uiSetRemainingTime(remainingTime) {
+				_uiSetRemainingTime(remainingTime, counterTextNode) {
 					var instance = this;
 
 					remainingTime = instance._formatTime(remainingTime);
 
 					if (!instance._alertClosed) {
-						var counterTextNode = document.getElementsByClassName(
-							'countdown-timer'
-						)[0];
+						var alert = counterTextNode.closest(
+							'div[role="alert"]'
+						);
+
+						// Prevent screen-reader from re-reading alert:
+
+						if (alert) {
+							alert.removeAttribute('role');
+
+							instance._alert = alert;
+						}
 
 						counterTextNode.innerHTML = remainingTime;
 					}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -572,6 +572,12 @@ AUI.add(
 							duration: 500,
 							message: instance._warningText,
 							on: {
+								blur() {
+									A.one('div[role="alert"').setAttribute(
+										'role',
+										'alert'
+									);
+								},
 								click(event) {
 									if (
 										event.domEvent.target.test(
@@ -587,6 +593,11 @@ AUI.add(
 										instance._destroyBanner();
 										instance._alertClosed = true;
 									}
+								},
+								focus() {
+									A.one('div[role="alert"').removeAttribute(
+										'role'
+									);
 								},
 							},
 							title: Liferay.Language.get('warning'),
@@ -641,23 +652,11 @@ AUI.add(
 					remainingTime = instance._formatTime(remainingTime);
 
 					if (!instance._alertClosed) {
-						var banner = instance._getBanner();
+						var counterTextNode = document.getElementsByClassName(
+							'countdown-timer'
+						)[0];
 
-						var bannerFocused = banner.bodyNode.contains(
-							document.activeElement
-						);
-
-						banner.set(
-							'message',
-							Lang.sub(instance._warningText, [remainingTime])
-						);
-
-						if (bannerFocused) {
-							banner.bodyNode
-								.all('a')
-								.item(0)
-								.focus();
-						}
+						counterTextNode.innerHTML = remainingTime;
 					}
 
 					DOC.title =


### PR DESCRIPTION
@antonio-ortega: this is [your pull](https://github.com/wincent/liferay-portal/pull/231) with [one commit](https://github.com/antonio-ortega/liferay-portal/commit/a5b9120f98c9990d2dbf7e03b24510d3eb32086b) added on top.

### Changes

Based on:

https://github.com/wincent/liferay-portal/pull/231

I think there were a few of problems with that approach:

- Missing "]" at end of selectors.
- `blur()` would explode, because as soon as we remove the `[role="alert"]`, the `A.one()` call has nothing to find, will return `null` and we die calling `.setAttribute()` on `null`.

So, this commit makes a few changes:

- If we always pass `counterTextNode` into `_uiSetRemainingTime()`, we don't need to re-find the node inside that method.
- Rather than finding `[role="alert"]` anywhere in the document, scope the search more tightly by using `.closest()` and starting from the counter.
- Store the found alert in `this._alert` so that we can find it later on when restoring the `[role="alert"]`.

The remaining problem:

I am not sure whether `blur()` is the right place to restore the role. For example, if I have focus on the alert close button, and I tab to the "Extend" button, `blur()` will fire because the close button lost focus, and that bubbles (apparently; that seems non-standard to me, but maybe it is an AUI thing, because that's what I'm seeing when I test this). As a result, `[role="alert"]` gets added back and then removed again after 1 second.

Notes on YUI and "blur" bubbling:

- https://yuilibrary.com/yui/docs/event/focus.html (they fake it).
- https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event (it is not supposed to bubble).

So one final change, I make sure we only blur when the focus really leaves the entire notification, using `contains()` and `relatedTarget`. Still need to confirm that that is right: for example, when the alert shows, we remove `[role="alert"]` after one second; if you then tab out of the alert, we add back the `[role="alert"]`, and one second later, it gets removed again.

### Original message

Hi @wincent ,

Although previous fixed avoided losing the focus, we've realized about a new issue: Screen readers are reading the whole banner from the beginning with every update.

I've discussed the issue with @marcoscv-work and @eduardoallegrini and they thought the best way to fix this behaviour should be to hide the banner to our screen reader, i.e., removing role="alert" when we are focusing the banner.

Additionally, although it is not strictly needed, I've included an extra change within _uiSetRemainingTime function to update only the counter instead the whole banner.
