### PR TITLE
LPS-118057 Allow attributes for paragraph.

### DIFF
--- a/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -65,7 +65,7 @@ public class BlogsContentEditorConfigContributor
 		sb.append(_getAllowedContentText());
 		sb.append(" div[*](*); iframe[*](*); img[*](*){*}; ");
 		sb.append(_getAllowedContentLists());
-		sb.append(" p {text-align}; ");
+		sb.append(" p[*](*){text-align}; ");
 		sb.append(_getAllowedContentTable());
 		sb.append(" video[*](*);");
 


### PR DESCRIPTION
Hello @antonio-ortega ,

https://issues.liferay.com/browse/LPS-118057

As we've discussed in slack, you were correct in that BlogsContentEditorConfigContributor was not allowing attributes for paragraph tag

I've noticed the proposed solution here is not implemented anywhere else in other ConfigContributors. 

I do see that users can use div tag instead as a workaround.


Please let me know if this solution is something that we want to pursue. 

Sincerely,
Brian Kim