### PR TITLE
LPS-118907 align search icon with wrapper

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/main.scss
@@ -2,3 +2,9 @@
 @import 'search_bar';
 @import 'search_facet';
 @import 'suggestions';
+
+.lfr-search-button-wrapper {
+	line-height: 2.5rem;
+	margin-left: -2rem;
+	position: absolute;
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view.jsp
@@ -57,7 +57,7 @@ pageContext.setAttribute("portletURL", portletURL);
 			</c:otherwise>
 		</c:choose>
 
-		<aui:field-wrapper inlineField="<%= true %>">
+		<aui:field-wrapper cssClass="lfr-search-button-wrapper" inlineField="<%= true %>">
 			<button class="btn btn-light btn-unstyled" onclick="<%= liferayPortletResponse.getNamespace() + "search();" %>" type="submit">
 				<liferay-ui:icon
 					cssClass="icon-monospaced"


### PR DESCRIPTION
Hey,
[LPS-118907](https://issues.liferay.com/browse/LPS-118907),

I know it's not frontend-infra, but a css change inside the _portal-search-web_ module, however the Search SME is on a longer PTO and I'd be interested if I made the right fix from a frontend perspective.

Please review my changes.

Thanks,

