### PR TITLE
FreeHTML - shows text undefined in preview when clicking outside of the source editor

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
@@ -135,9 +135,11 @@ AUI.add(
 				_onEditorChange(event) {
 					var instance = this;
 
-					instance._previewPanel.html(
-						instance._getHtml(event.newVal)
-					);
+					if (event.newVal) {
+						instance._previewPanel.html(
+							instance._getHtml(event.newVal)
+						);
+					}
 				},
 
 				_onLayoutChange(event) {


### PR DESCRIPTION
Hey,

[LPS-121775](https://issues.liferay.com/browse/LPS-121775)
When we click outside of the editor the value we render is undefined, I made a null check to solve it.
Please review my changes.

Thanks,