### PR TITLE
[TS] LPS-121651 Navigation Errors with Inactive Sites

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib
 Bundle-SymbolicName: com.liferay.frontend.taglib
-Bundle-Version: 5.4.6
+Bundle-Version: 5.5.0
 Export-Package:\
 	com.liferay.frontend.taglib.servlet.taglib,\
 	com.liferay.frontend.taglib.servlet.taglib.base,\

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -21,5 +21,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "5.4.6"
+	"version": "5.5.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/VerticalCardTag.java
@@ -55,6 +55,10 @@ public class VerticalCardTag extends CardTag {
 		_backgroundImage = backgroundImage;
 	}
 
+	public void setDataSennaOff(boolean dataSennaOff) {
+		_dataSennaOff = dataSennaOff;
+	}
+
 	public void setFooter(String footer) {
 		_footer = footer;
 	}
@@ -84,6 +88,7 @@ public class VerticalCardTag extends CardTag {
 		super.cleanUp();
 
 		_backgroundImage = true;
+		_dataSennaOff = false;
 		_footer = null;
 		_header = null;
 		_onClick = null;
@@ -103,6 +108,8 @@ public class VerticalCardTag extends CardTag {
 
 		httpServletRequest.setAttribute(
 			"liferay-frontend:card:backgroundImage", _backgroundImage);
+		request.setAttribute(
+			"liferay-frontend:card:dataSennaOff", _dataSennaOff);
 		httpServletRequest.setAttribute(
 			"liferay-frontend:card:footer", _footer);
 		httpServletRequest.setAttribute(
@@ -117,6 +124,7 @@ public class VerticalCardTag extends CardTag {
 	}
 
 	private boolean _backgroundImage = true;
+	private boolean _dataSennaOff;
 	private String _footer;
 	private String _header;
 	private String _onClick;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -836,6 +836,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>The data-senna-off value on the anchor link.</description>
+			<name>dataSennaOff</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>icon</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1549,6 +1555,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>The data-senna-off value on the anchor link.</description>
+			<name>dataSennaOff</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>If you pass in a row checker value, a result row is mandatory. A result row is of type <![CDATA[<code>com.liferay.portal.kernel.dao.search.ResultRow</code>]]>.</description>
 			<name>resultRow</name>
 			<required>false</required>
@@ -1669,6 +1681,12 @@
 		<attribute>
 			<description>Miscellaneous data to be stored via a map. This data is not shared with the browser. The map holds key value pairs of type <![CDATA[<code>&lt;String, Object&gt;</code>]]>.</description>
 			<name>data</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The data-senna-off value on the anchor link.</description>
+			<name>dataSennaOff</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0

--- a/modules/apps/portal/portal-inactive-request-handler/bnd.bnd
+++ b/modules/apps/portal/portal-inactive-request-handler/bnd.bnd
@@ -1,3 +1,5 @@
 Bundle-Name: Liferay Portal Inactive Request Handler
 Bundle-SymbolicName: com.liferay.portal.inactive.request.handler
 Bundle-Version: 3.0.11
+Export-Package:\
+	com.liferay.portal.inactive.request.handler.configuration

--- a/modules/apps/site/site-item-selector-web/build.gradle
+++ b/modules/apps/site/site-item-selector-web/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")
+	compileOnly project(":apps:portal:portal-inactive-request-handler")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-item-selector-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -25,8 +25,10 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.item.selector.criteria.group.criterion.GroupItemSelectorCriterion" %><%@
+page import="com.liferay.portal.inactive.request.handler.configuration.InactiveRequestHandlerConfiguration" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
+page import="com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil" %><%@
 page import="com.liferay.portal.kernel.service.GroupServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@

--- a/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
+++ b/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
@@ -27,6 +27,10 @@ GroupItemSelectorCriterion groupItemSelectorCriterion = siteItemSelectorViewDisp
 String target = ParamUtil.getString(request, "target", groupItemSelectorCriterion.getTarget());
 
 GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
+
+InactiveRequestHandlerConfiguration inactiveRequestHandlerConfiguration = ConfigurationProviderUtil.getSystemConfiguration(InactiveRequestHandlerConfiguration.class);
+
+boolean showInactiveRequestMessage = inactiveRequestHandlerConfiguration.showInactiveRequestMessage();
 %>
 
 <clay:management-toolbar
@@ -85,6 +89,8 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 
 				childGroupsHREF = childGroupsURL.toString();
 			}
+
+			boolean dataSennaOff = showInactiveRequestMessage && !group.isActive();
 			%>
 
 			<c:choose>
@@ -106,7 +112,7 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 						colspan="<%= 2 %>"
 					>
 						<h5>
-							<aui:a cssClass="selector-button" data="<%= data %>" href="javascript:;">
+							<aui:a cssClass="selector-button" data="<%= data %>" data-senna-off="<%= dataSennaOff %>" href="javascript:;">
 								<%= HtmlUtil.escape(siteItemSelectorViewDisplayContext.getGroupName(group)) %>
 							</aui:a>
 
@@ -169,7 +175,7 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 										expand="<%= true %>"
 										gutters="<%= true %>"
 									>
-										<aui:a cssClass="card-title selector-button text-truncate" data="<%= data %>" href="javascript:;" title="<%= siteVerticalCard.getSubtitle() %>">
+										<aui:a cssClass="card-title selector-button text-truncate" data="<%= data %>" data-senna-off="<%= dataSennaOff %>" href="javascript:;" title="<%= siteVerticalCard.getSubtitle() %>">
 											<%= siteVerticalCard.getTitle() %>
 										</aui:a>
 
@@ -195,7 +201,7 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 						name="name"
 						truncate="<%= true %>"
 					>
-						<aui:a cssClass="selector-button" data="<%= data %>" href="javascript:;">
+						<aui:a cssClass="selector-button" data="<%= data %>" data-senna-off="<%= dataSennaOff %>" href="javascript:;">
 							<%= HtmlUtil.escape(siteItemSelectorViewDisplayContext.getGroupName(group)) %>
 						</aui:a>
 


### PR DESCRIPTION
Hi @antonio-ortega 

the site navigation are used at the following places:
1. Site administration (Control Panel > Sites)
2. Site Item Selector (Compass icon in Product Menu)
3. My Sites Portlet (list of sites in 'My Dashboard)

For further testing the Inactive Request Handler should be checked at Control Panel > Configuration > System Settings > Infrastructure > Inactive Request Handler and site (My site) should be deactivated.

In the **1st** case the site navigates to the site admin web, we dont need to add the data-senna-off atribure.

In the **2nd** case the site navigates to the http://localhost:8080/web/my-site and the "This site is inactive. Please contact the administrator." page loads. Based on my tests after refreshing the page and navigating back i still see the inactive message. I implemented the same fix on 70x and on that branch it works for me. - Could you please check this on your side?

In the **3rd** case the page opens in a new browser tab, we dont need here neither the data-senna-off atribure.

Beside that i added the dataSennaOff attribute to the vertical-card, user-vertical and icon-vertical card taglibs which will be used on the 71x and 70x branches but the code will be more consistent among branches.

See details on the PTR:
https://issues.liferay.com/browse/PTR-1968?focusedCommentId=2279647&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2279647


https://issues.liferay.com/browse/LPS-121651