### PR TITLE
LPS-123371 Handle if selectedData is undefined

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1544,7 +1544,7 @@
 					}
 
 					var disabled =
-						selectedData && selectedData.includes(assetEntryId);
+						!!selectedData && selectedData.includes(assetEntryId);
 
 					if (disabled) {
 						item.attr('data-prevent-selection', true);


### PR DESCRIPTION
Hi @antonio-ortega 

The LPS-123371 is reproducable only on 72x, because the Liferay.Util.selectEntity is used in 72x only, 
on master/73x we started to use the Liferay.Util.openSelectionModal.

On master we are using the Liferay.Util.selectEntity only at the ItemSelectorDialog.es.js
https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/ItemSelectorDialog.es.js#L62-L71

I would like to send the fix to master too, becuase the Liferay.Util.selectEntity is still used,
and we still have the Liferay.Util.selectEntity in the util.js

The case:  if the selectedData is undefined than the disabled value will be undefined too.
The fix:  if the selectedData is undefined, than the !!selectedData will be false, and the disabled value will be false too. 

Thanks, Roland

https://issues.liferay.com/browse/LPS-123371