### PR TITLE
[TECHNICAL SUPPORT] LPS-131494 Can't remove inherited styling after pasting into ckeditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -210,6 +210,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 		JSONArray jsonArray = JSONUtil.putAll(
 			toJSONArray("['Undo', 'Redo']"),
 			toJSONArray("['Styles', 'Bold', 'Italic', 'Underline']"),
+			toJSONArray("['RemoveFormat']"),
 			toJSONArray("['NumberedList', 'BulletedList']"),
 			toJSONArray("['Link', Unlink]"),
 			toJSONArray("['Table', 'ImageSelector', 'VideoSelector']"));


### PR DESCRIPTION
Hello,

[LPS-131494](https://issues.liferay.com/browse/LPS-131494)
As we allow any content into the editor, I think we should ship our simple toolbar with the RemoveFormat plugin as well to make sure the user has an option to remove unwanted styles that our other plugins are not capable of.

Please review my changes,

Thanks